### PR TITLE
Support negative lags in RV metric

### DIFF
--- a/phys2denoise/metrics/chest_belt.py
+++ b/phys2denoise/metrics/chest_belt.py
@@ -70,8 +70,9 @@ def env(belt_ts, samplerate, out_samplerate, window=10, lags=(0,)):
         Size of the sliding window, in the same units as out_samplerate.
         Default is 6.
     lags : (Y,) :obj:`tuple` of :obj:`int`, optional
-        List of lags to apply to the rv estimate. In the same units as
-        out_samplerate.
+        List of lags to apply to the env estimate.
+        Lags can be negative, zero, and/or positive.
+        In seconds (like out_samplerate).
 
     Returns
     -------
@@ -118,8 +119,9 @@ def rv(belt_ts, samplerate, out_samplerate, window=6, lags=(0,)):
         Size of the sliding window, in the same units as out_samplerate.
         Default is 6.
     lags : (Y,) :obj:`tuple` of :obj:`int`, optional
-        List of lags to apply to the rv estimate. In the same units as
-        out_samplerate.
+        List of lags to apply to the rv estimate.
+        Lags can be negative, zero, and/or positive.
+        In seconds (like out_samplerate).
 
     Returns
     -------

--- a/phys2denoise/metrics/chest_belt.py
+++ b/phys2denoise/metrics/chest_belt.py
@@ -54,7 +54,7 @@ def rpv(belt_ts, window):
 
 
 @due.dcite(references.POWER_2020)
-def env(belt_ts, samplerate, out_samplerate, window=10, lags=(0,)):
+def env(belt_ts, samplerate, out_samplerate, window=10):
     """Calculate respiratory pattern variability across a sliding window.
 
     Parameters
@@ -69,10 +69,6 @@ def env(belt_ts, samplerate, out_samplerate, window=10, lags=(0,)):
     window : :obj:`int`, optional
         Size of the sliding window, in the same units as out_samplerate.
         Default is 6.
-    lags : (Y,) :obj:`tuple` of :obj:`int`, optional
-        List of lags to apply to the env estimate.
-        Lags can be negative, zero, and/or positive.
-        In seconds (like out_samplerate).
 
     Returns
     -------

--- a/phys2denoise/metrics/chest_belt.py
+++ b/phys2denoise/metrics/chest_belt.py
@@ -150,7 +150,7 @@ def rv(belt_ts, samplerate, out_samplerate, window=6, lags=(0,)):
     # Apply lags
     n_out_samples = int((belt_ts.shape[0] / samplerate) / out_samplerate)
     # convert lags from out_samplerate to samplerate
-    delays = [abs(int(lag * samplerate)) for lag in lags]
+    delays = [int(lag * samplerate) for lag in lags]
     rv_with_lags = utils.apply_lags(rv_arr, lags=delays)
 
     # Downsample to out_samplerate


### PR DESCRIPTION
<!-- Write all of the issues that are linked to this pull request. -->
<!-- If this PR is enough to close them you can write something like "Closes #314 and closes #42" -->
<!-- If you just want to reference them without closing them, you can add something like "References #112" -->
Closes #35.

<!-- Add a short description of the PR content here-->
This PR eliminates a step where lags are converted to their absolute values before they're applied to the respiratory variance time series.

## Proposed Changes
<!-- List major points of changes here, so that the reviewers can have a bit more context while looking at your work! -->
  - Do not take absolute value of lags before applying to RV time series. This will allow the function to support negative lags.
  - Remove the unused lags argument from the env function.
  - Improve the documentation of the lags argument in the rv function.

## Change Type
<!-- Indicate the type of change you think your pull request is -->
- [ ] `bugfix` (+0.0.1)
- [ ] `minor` (+0.1.0)
- [ ] `major`  (+1.0.0)
- [ ] `refactoring` (no version update)
- [ ] `test` (no version update)
- [ ] `infrastructure` (no version update)
- [ ] `documentation` (no version update)
- [ ] `other`

## Checklist before review
<!-- If this section is not clear, please read this part of the docs: https://phys2bids.readthedocs.io/en/latest/contributorfile.html#pr -->
<!-- You're invited to open a draft PR ASAP, but before marking it "ready for review", check that you have done the following: -->
- [ ] I added everything I wanted to add to this PR.
- [ ] \[Code or tests only\] I wrote/updated the necessary docstrings.
- [ ] \[Code or tests only\] I ran and passed tests locally.
- [ ] \[Documentation only\] I built the docs locally.
- [ ] My contribution is harmonious with the rest of the code: I'm not introducing repetitions.
- [ ] My code respects the adopted style, especially linting conventions.
- [ ] The title of this PR is explanatory on its own, enough to be understood as part of a changelog.
- [ ] I added or indicated the right labels.
<!-- If relevant, you can add a milestone label or indicate an ideal timeline for this PR, including whether the progress of this PR is linked to other PRs being completed before or after it. -->
- [ ] I added information regarding the timeline of completion for this PR.
<!-- If you want, you can ask for reviews on a draft PR -->
- [ ] Please, comment on my PR while it's a draft and give me feedback on the development!
